### PR TITLE
Deprecate project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Liqo Public Peering Dashboard
 
+⚠️ This Project is Deprecated ⚠️
+
+Please note: This repository is no longer actively maintained and is considered deprecated. We encourage you to explore alternative solutions or repositories that are actively developed.
+
+------
+
 The *Liqo public peering dashboard* is an open-source, web-based dashboard that exposes the status of the Liqo peerings established with the current cluster (both incoming and outgoing), and the amount of resources (i.e., in terms of vCPUs and memory) used/offered in each peering.
 
 ![Preview](./doc/images/screenshot.png)


### PR DESCRIPTION
This PR adds a banner inside the README file to deprecate this project.

After the liqo v1.0.0 refactoring, the dashboard won't be compatible with the new liqo APIs anymore.

Can you also archive this repository?